### PR TITLE
Check if players have cells when compiling the leaderboard #52

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@ cli/logs
 cli/settings.json
 cli/log-settings.json
 
+# logs
+logs
+
+# settings
+settings.json
+log-settings.json
+
 # npm
 node_modules
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
         "url": "https://github.com/Luka967/OgarII/issues"
     },
     "dependencies": {
-        "uws": "10.148.1"
+        "@clusterws/cws": "^0.16.0"
     }
 }

--- a/src/gamemodes/FFA.js
+++ b/src/gamemodes/FFA.js
@@ -48,7 +48,7 @@ class FFA extends Gamemode {
      * @param {World} world
      */
     compileLeaderboard(world) {
-        world.leaderboard = world.players.slice(0).filter((v) => !isNaN(v.score)).sort((a, b) => b.score - a.score);
+        world.leaderboard = world.players.slice(0).filter((v) => !isNaN(v.score) && v.ownedCells && v.ownedCells.length > 0).sort((a, b) => b.score - a.score);
     }
 
     /**

--- a/src/gamemodes/FFA.js
+++ b/src/gamemodes/FFA.js
@@ -9,8 +9,8 @@ const Misc = require("../primitives/Misc");
 function getLeaderboardData(player, requesting, index) {
     return {
         name: player.leaderboardName,
-        highlighted: requesting.id === player.id,
-        cellId: player.ownedCells[0].id,
+        highlighted: (requesting || { }).id === (player || { }).id,
+        cellId: (player.ownedCells[0] || { }).id,
         position: 1 + index
     };
 }

--- a/src/gamemodes/FFA.js
+++ b/src/gamemodes/FFA.js
@@ -58,6 +58,7 @@ class FFA extends Gamemode {
         if (!connection.hasPlayer) return;
         const player = connection.player;
         if (!player.hasWorld) return;
+	if (!player.id) return;
         if (player.world.frozen) return;
         /** @type {Player[]} */
         const leaderboard = player.world.leaderboard;

--- a/src/sockets/Connection.js
+++ b/src/sockets/Connection.js
@@ -179,7 +179,7 @@ class Connection extends Router {
 
 module.exports = Connection;
 
-const WebSocket = require("uws");
+const { WebSocket } = require("@clusterws/cws");
 const Listener = require("./Listener");
 const Minion = require("../bots/Minion");
 const Protocol = require("../protocols/Protocol");

--- a/src/sockets/Listener.js
+++ b/src/sockets/Listener.js
@@ -1,5 +1,4 @@
-const WebSocket = require("uws");
-const WebSocketServer = WebSocket.Server;
+const { WebSocket, WebSocketServer } = require("@clusterws/cws");
 
 const Connection = require("./Connection");
 const ChatChannel = require("./ChatChannel");


### PR DESCRIPTION
State is inconsistent, either `score` isn’t being updated before the leaderboard is compiled, or it’s not reactive at all to `ownedCells`. Spoke with Luka directly when I encountered this a few months ago, it’s likely a timing bug.